### PR TITLE
CI に型チェック（tsc --noEmit）を追加し tsconfig を TS7 対応にする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,7 @@ jobs:
           bun-version: latest
       - name: Install Dependencies
         run: bun install
+      - name: Type check
+        run: bun run typecheck
       - name: Run test
         run: bun run test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "repository": {

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -6,5 +6,5 @@ console.log(value);
 value = 'foo';
 
 console.log(value);
-value = null;
+// value = null; // Error: null は number | string に代入不可
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,6 @@
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node10" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */


### PR DESCRIPTION
Closes #556

## なぜ

Vitest 移行（#555）でテストランナーは TypeScript のバージョンに依存しなくなったが、Vitest は esbuild ベースでトランスパイルのみを行うため **型チェックが CI で行われない**状態だった（#556）。型エラーを CI で検出できるよう `tsc --noEmit` ステップを追加する。

型チェックを導入する過程で、以下の既存問題も判明したため併せて修正する（型チェックを通すのに不可分なため同一 PR）:

- **tsconfig が TypeScript 7 非互換**: #554 で TS を 7 に上げた際、tsconfig が追従していなかった。Vitest はトランスパイルのみで tsconfig を厳密に見ないため露見していなかった。
- **教材コードの型エラー**: `src/types/union.ts` に union 型へ null を代入する行があった。

## 変更点

- `tsconfig.json`: TypeScript 7 で削除された `moduleResolution: "node10"` と `baseUrl` を除去（非相対 import は未使用のため影響なし）
- `src/types/union.ts`: `number | string` へ `null` を代入する行をコメントアウト（「null は代入不可」という教材上の意図はコメントで保持）
- `package.json`: `typecheck` スクリプト（`tsc --noEmit`）を追加
- `.github/workflows/main.yml`: test の前に `bun run typecheck` ステップを追加

## 検証

- `bun run typecheck` — PASS（exit 0、型エラーなし）
- `bun run test` — 全 5 スイート・16 テスト green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
